### PR TITLE
Issue: Refactor error handling in PowerShell scripts and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ password.txt
 case
 .trash
 tests.ps1
+tests.txt
+tests.csv

--- a/scripts/private/get-entrausers.ps1
+++ b/scripts/private/get-entrausers.ps1
@@ -43,14 +43,14 @@ Write-Verbose -Message "Checking requirements ..."
 # Check if PowerShell version is 7.4 or higher
 if ($PSVersionTable.PSVersion.Major -lt 7) {
     Write-Verbose -Message "PowerShell version is lower than 7.4, actual version is $($PSVersionTable.PSVersion) ..."
-    Write-Output -ForegroundColor Red "PowerShell version 7.4 or higher is required"
+    Write-Error -Message "PowerShell version 7.4 or higher is required" -Category NotInstalled
     exit
 }
 
 # Check if module is already installed
 if (-not (Get-Module -Name Microsoft.Graph -ListAvailable)) {
     Write-Verbose -Message "Microsoft.Graph module not found ..."
-    Write-Output -ForegroundColor Red "Microsoft.Graph module not found, please install it first"
+    Write-Error -Message "Microsoft.Graph module not found, please install it first" -Category NotInstalled
     exit
 }
 
@@ -100,7 +100,7 @@ Connect-MgGraph -NoWelcome
 # Check if the connection was successful
 if ($null -eq (Get-MgUser)) {
     Write-Verbose -Message "Connection to Microsoft Graph failed!"
-    Write-Output -ForegroundColor Red "Failed to connect to Microsoft Graph. Please check your credentials and permissions."
+    Write-Error -Message "Failed to connect to Microsoft Graph. Please check your credentials and permissions." -Category ConnectionError
     exit
 }
 

--- a/scripts/private/get-rolesassignment.ps1
+++ b/scripts/private/get-rolesassignment.ps1
@@ -43,14 +43,14 @@ Write-Verbose -Message "Checking requirements ..."
 # Check if PowerShell version is 7.4 or higher
 if ($PSVersionTable.PSVersion.Major -lt 7) {
     Write-Verbose -Message "PowerShell version is lower than 7.4, actual version is $($PSVersionTable.PSVersion) ..."
-    Write-Output -ForegroundColor Red "PowerShell version 7.4 or higher is required"
+    Write-Error -Message "PowerShell version 7.4 or higher is required" -Category NotInstalled
     exit
 }
 
 # Check if module is already installed
 if (-not (Get-Module -Name Az -ListAvailable)) {
     Write-Verbose -Message "Az module not found ..."
-    Write-Output -ForegroundColor Red "Az module not found, please install it first"
+    Write-Error -Message "Az module not found, please install it first" -Category NotInstalled
     exit
 }
 
@@ -91,7 +91,7 @@ Connect-AzAccount
 $azContext = Get-AzContext
 if ($null -eq $azContext) {
     Write-Verbose -Message "Failed to connect to Azure ..."
-    Write-Output -ForegroundColor Red "Failed to connect to Azure. Please check your credentials and permissions."
+    Write-Error -Message "Failed to connect to Azure. Please check your credentials and permissions." -Category ConnectionError
     exit
 }
 

--- a/scripts/private/get-storageaccounts.ps1
+++ b/scripts/private/get-storageaccounts.ps1
@@ -43,14 +43,14 @@ Write-Verbose -Message "Checking requirements ..."
 # Check if PowerShell version is 7.4 or higher
 if ($PSVersionTable.PSVersion.Major -lt 7) {
     Write-Verbose -Message "PowerShell version is lower than 7.4, actual version is $($PSVersionTable.PSVersion) ..."
-    Write-Output -ForegroundColor Red "PowerShell version 7.4 or higher is required"
+    Write-Error -Message "PowerShell version 7.4 or higher is required" -Category NotInstalled
     exit
 }
 
 # Check if module is already installed
 if (-not (Get-Module -Name Az -ListAvailable)) {
     Write-Verbose -Message "Az module not found ..."
-    Write-Output -ForegroundColor Red "Az module not found, please install it first"
+    Write-Error -Message "Az module not found, please install it first" -Category NotInstalled
     exit
 }
 
@@ -91,7 +91,7 @@ Connect-AzAccount
 $azContext = Get-AzContext
 if ($null -eq $azContext) {
     Write-Verbose -Message "Failed to connect to Azure ..."
-    Write-Output -ForegroundColor Red "Failed to connect to Azure. Please check your credentials and permissions."
+    Write-Error -Message "Failed to connect to Azure. Please check your credentials and permissions." -Category ConnectionError
     exit
 }
 

--- a/scripts/private/get-storageblob.ps1
+++ b/scripts/private/get-storageblob.ps1
@@ -75,14 +75,14 @@ Write-Verbose -Message "Checking requirements ..."
 # Check if PowerShell version is 7.4 or higher
 if ($PSVersionTable.PSVersion.Major -lt 7) {
     Write-Verbose -Message "PowerShell version is lower than 7.4, actual version is $($PSVersionTable.PSVersion) ..."
-    Write-Output -ForegroundColor Red "PowerShell version 7.4 or higher is required"
+    Write-Error -Message "PowerShell version 7.4 or higher is required" -Category NotInstalled
     exit
 }
 
 # Check if module is already installed
 if (-not (Get-Module -Name Az -ListAvailable)) {
     Write-Verbose -Message "Az module not found ..."
-    Write-Output -ForegroundColor Red "Az module not found, please install it first"
+    Write-Error -Message "Az module not found, please install it first" -Category NotInstalled
     exit
 }
 
@@ -130,7 +130,7 @@ Connect-AzAccount
 $azContext = Get-AzContext
 if ($null -eq $azContext) {
     Write-Verbose -Message "Failed to connect to Azure ..."
-    Write-Output -ForegroundColor Red "Failed to connect to Azure. Please check your credentials and permissions."
+    Write-Error -Message "Failed to connect to Azure. Please check your credentials and permissions." -Category ConnectionError
     exit
 }
 
@@ -146,7 +146,7 @@ switch($PSCmdlet.ParameterSetName) {
         $blobik = Get-AzStorageBlob -Container $Container -Context $Context -Blob $Blob
 
         if ($null -eq $blobik) {
-            Write-Output -ForegroundColor Red "Blob not found. Please check the blob name and container."
+            Write-Error -Message "Blob not found. Please check the blob name and container." -Category ObjectNotFound
             exit
         }
 
@@ -157,7 +157,7 @@ switch($PSCmdlet.ParameterSetName) {
         if (Test-Path -Path $blobPath) {
             Write-Output "Blob downloaded successfully to $blobPath"
         } else {
-            Write-Output -ForegroundColor Red "Failed to download the blob."
+            Write-Error -Message "Failed to download the blob."
         }
     }
 
@@ -169,7 +169,7 @@ switch($PSCmdlet.ParameterSetName) {
         $blobik = Get-AzStorageBlob -Container $Container -Context $Context -Blob $Blob -VersionId $VersionId
 
         if ($null -eq $blobik) {
-            Write-Output -ForegroundColor Red "Blob not found. Please check the blob name, version id and container."
+            Write-Error -Message "Blob not found. Please check the blob name, version id and container." -Category ObjectNotFound
             exit
         }
 
@@ -180,7 +180,7 @@ switch($PSCmdlet.ParameterSetName) {
         if (Test-Path -Path $blobPath) {
             Write-Output "Blob downloaded successfully to $blobPath"
         } else {
-            Write-Output -ForegroundColor Red "Failed to download the blob."
+            Write-Error -Message "Failed to download the blob."
         }
     }
 }

--- a/scripts/private/get-virtualmachines.ps1
+++ b/scripts/private/get-virtualmachines.ps1
@@ -43,14 +43,14 @@ Write-Verbose -Message "Checking requirements ..."
 # Check if PowerShell version is 7.4 or higher
 if ($PSVersionTable.PSVersion.Major -lt 7) {
     Write-Verbose -Message "PowerShell version is lower than 7.4, actual version is $($PSVersionTable.PSVersion) ..."
-    Write-Output -ForegroundColor Red "PowerShell version 7.4 or higher is required"
+    Write-Error -Message "PowerShell version 7.4 or higher is required" -Category NotInstalled
     exit
 }
 
 # Check if module is already installed
 if (-not (Get-Module -Name Az -ListAvailable)) {
     Write-Verbose -Message "Az module not found ..."
-    Write-Output -ForegroundColor Red "Az module not found, please install it first"
+    Write-Error -Message "Az module not found, please install it first" -Category NotInstalled
     exit
 }
 
@@ -91,7 +91,7 @@ Connect-AzAccount
 $azContext = Get-AzContext
 if ($null -eq $azContext) {
     Write-Verbose -Message "Failed to connect to Azure ..."
-    Write-Output -ForegroundColor Red "Failed to connect to Azure. Please check your credentials and permissions."
+    Write-Error -Message "Failed to connect to Azure. Please check your credentials and permissions." -Category ConnectionError
     exit
 }
 

--- a/scripts/private/get-visibleresources.ps1
+++ b/scripts/private/get-visibleresources.ps1
@@ -42,14 +42,14 @@ Write-Verbose -Message "Checking requirements ..."
 # Check if PowerShell version is 7.4 or higher
 if ($PSVersionTable.PSVersion.Major -lt 7) {
     Write-Verbose -Message "PowerShell version is lower than 7.4, actual version is $($PSVersionTable.PSVersion) ..."
-    Write-Output -ForegroundColor Red "PowerShell version 7.4 or higher is required"
+    Write-Error -Message "PowerShell version 7.4 or higher is required" -Category NotInstalled
     exit
 }
 
 # Check if module is already installed
 if (-not (Get-Module -Name Az -ListAvailable)) {
     Write-Verbose -Message "Az module not found ..."
-    Write-Output -ForegroundColor Red "Az module not found, please install it first"
+    Write-Error -Message "Az module not found, please install it first" -Category NotInstalled
     exit
 }
 
@@ -90,7 +90,7 @@ Connect-AzAccount
 $azContext = Get-AzContext
 if ($null -eq $azContext) {
     Write-Verbose -Message "Failed to connect to Azure ..."
-    Write-Output -ForegroundColor Red "Failed to connect to Azure. Please check your credentials and permissions."
+    Write-Error -Message "Failed to connect to Azure. Please check your credentials and permissions." -Category ConnectionError
     exit
 }
 

--- a/scripts/public/test-websites.ps1
+++ b/scripts/public/test-websites.ps1
@@ -1,249 +1,101 @@
+<#
 
+.NOTES
+    The output is saved in a text file located in a case-specific folder under the "case" directory.
+
+    Author: David Burel (@dafneb)
+    Date: April 18, 2025
+    Version: 1.0.0
+#>
 
 # Define the script's parameters
 [CmdletBinding(DefaultParameterSetName = 'Uri')]
 param (
+    [Parameter(Mandatory = $true, ParameterSetName = "Uri")]
+    [Parameter(Mandatory = $true, ParameterSetName = 'File')]
+    [ValidateNotNullOrEmpty()]
+    [string]$CaseName = "case-name",
+
     [Parameter(Mandatory = $true, ParameterSetName = 'Uri')]
     [ValidateNotNullOrEmpty()]
-    [string[]]$Uri = "website-uri"
+    [string[]]$Uri = "website-uri",
+
+    [Parameter(Mandatory = $true, ParameterSetName = 'File')]
+    [ValidateNotNullOrEmpty()]
+    [string]$FilePath
 )
 
-# Get the content ... 
-if ($PSCmdlet.ParameterSetName -eq 'Uri') {
-    # Get addresses from $Uri parameter
-    $Uri | ForEach-Object {
-        $address = $_.Trim()
-        try {
-            $websiteUri = New-Object System.UriBuilder($address)
-        } catch {
-            Write-Host "Error processing address: $address"
-            continue
-        }
+$timeStart = Get-Date
 
-        # Paths for logs
-        $basePath = Join-Path -Path (Get-Location) -ChildPath "case"
-        $logFolder = Join-Path -Path $basePath -ChildPath $websiteUri.Host
-        $webFolder = Join-Path -Path $logFolder -ChildPath $websiteUri.Path
-        $logFile = Join-Path -Path $webFolder -ChildPath "test-website.txt"
+Write-Output "***********************************************************"
+Write-Output "*********** Websites mining *******************************"
+Write-Output "*********** Author: David Burel (@dafneb) *****************"
+Write-Output "***********************************************************"
 
-        # Create case folder if it doesn't exist
-        if (-not (Test-Path -Path $basePath)) {
-            New-Item -ItemType Directory -Path $basePath | Out-Null
-        }
-        # Create website folder if it doesn't exist
-        if (-not (Test-Path -Path $logFolder)) {
-            New-Item -ItemType Directory -Path $logFolder | Out-Null
-        }
-        if (-not (Test-Path -Path $webFolder)) {
-            New-Item -ItemType Directory -Path $webFolder | Out-Null
-        }
-        # Create log file if it doesn't exist
-        if (-not (Test-Path -Path $logFile)) {
-            New-Item -ItemType File -Path $logFile | Out-Null
-        } else {
-            Clear-Content -Path $logFile
-        }
+Write-Verbose -Message "Checking requirements ..."
 
-        # Array for results
-        $dataWebsite = @()
-        $dataWebsite += "URI: $($websiteUri.Uri)"
-
-        # Let's check if the website is accessible
-        try {
-            $response = Invoke-WebRequest -Uri $websiteUri.Uri
-            $dataWebsite += "`tStatusCode: $($response.StatusCode)"
-            $dataWebsite += "`tStatusDescription: $($response.StatusDescription)"
-        } catch {
-            Write-Host "Failed to access the website. StatusCode: $($_.Exception.Response.StatusCode.value__)"
-            $dataWebsite += "`tStatusCode: $($_.Exception.Response.StatusCode.value__)"
-            $dataWebsite | ForEach-Object { Add-Content -Path $logFile -Value $_ }
-            continue
-        }
-
-        # Let's evaluate the response if StatusCode is 200
-        if ($response.StatusCode -eq 200) {
-
-            # Check headers and try to find if response is from a blob storage
-            $dataWebsite += "`tHeaders:"
-            $response.Headers.Keys | ForEach-Object {
-                $key = $_
-                $dataWebsite += "`t`t$($key): $($response.Headers[$key] -Join ', ')"
-                switch ($key) {
-                    'Server' {
-                        if ($response.Headers[$key] -match 'Windows-Azure-Blob/.*') {
-                            $dataWebsite += "`t`t`tIt's possibly a blob storage."
-                        }
-                    }
-                    'x-ms-blob-type' {
-                        if ($response.Headers[$key] -match 'BlockBlob') {
-                            $dataWebsite += "`t`t`tIt's possibly a blob storage."
-                        }
-                    }
-                    Default {}
-                }
-            }
-            # Check if the website contains any link to a blob storage
-            # Pattern for all services under StorageAccount 'https://([0-9a-z]{3,24})\.(blob|web|dfs|file|queue|table)\.core\.windows\.net/([0-9a-z-_$]{3,63})/'
-            $dataWebsite += "`tChecking for regular expression against context:"    
-            $dataWebsite += "`t`tPattern: (?<endpoint>https://(?<storageacc>[0-9a-z]{3,24})\.blob\.core\.windows\.net)/(?<container>[0-9a-z-_$]{3,63})/"    
-            $results = $response.Content | Select-String -Pattern '(?<endpoint>https://(?<storageacc>[0-9a-z]{3,24})\.blob\.core\.windows\.net)/(?<container>[0-9a-z-_$]{3,63})/' -AllMatches
-            # We want to get unique matches
-            $uniqueMatches = $results.Matches | Select-Object -Unique
-            $dataWebsite += "`t`tUnique Matches:"
-            $uniqueMatches | ForEach-Object {
-                # Let's check each match
-                $dataWebsite += "`t`t`tValue: $($_.Value)"
-                $dataWebsite += "`t`t`tEndpoint: $($_.Groups['endpoint'].Value)"
-                $dataWebsite += "`t`t`tStorageAccount: $($_.Groups['storageacc'].Value)"
-                $dataWebsite += "`t`t`tContainer: $($_.Groups['container'].Value)"
-                # Create URI for request to same path
-                $uriBuilder = New-Object System.UriBuilder($_.Value)
-                $uriBuilder.Path = $websiteUri.Path # Let's check if we can find same path
-                $dataWebsite += "`t`t`tURI: $($uriBuilder.Uri)"
-                try {
-                    $check = Invoke-WebRequest -Uri $uriBuilder.Uri -Method Head
-                    $dataWebsite += "`t`t`t`tStatusCode: $($check.StatusCode)"
-                    $dataWebsite += "`t`t`t`tStatusDescription: $($check.StatusDescription)"
-                    $dataWebsite += "`t`t`t`tHeaders:"
-                    $check.Headers.Keys | ForEach-Object {
-                        $key = $_
-                        $dataWebsite += "`t`t`t`t`t$($key): $($check.Headers[$key] -Join ', ')"
-                        switch ($key) {
-                            'Server' {
-                                if ($check.Headers[$key] -match 'Windows-Azure-Blob/.*') {
-                                    $dataWebsite += "`t`t`t`t`t`tIt's possibly a blob storage."
-                                }
-                            }
-                            'x-ms-blob-type' {
-                                if ($check.Headers[$key] -match 'BlockBlob') {
-                                    $dataWebsite += "`t`t`t`t`t`tIt's possibly a blob storage."
-                                }
-                            }
-                            Default {}
-                        }
-                    }
-            
-                } catch {
-                    $dataWebsite += "`t`t`t`tStatusCode: $($_.Exception.Response.StatusCode.value__)"
-                }
-                # Let's check another API calls to the blob storage
-                $storageAccount = $_.Groups['storageacc'].Value
-                $storageFolder = Join-Path -Path $logFolder -ChildPath $storageAccount
-                # Create storage account folder if it doesn't exist
-                if (-not (Test-Path -Path $storageFolder)) {
-                    New-Item -ItemType Directory -Path $storageFolder | Out-Null
-                }
-                $container = $_.Groups['container'].Value
-                $containerFolder = Join-Path -Path $storageFolder -ChildPath $container
-                # Create container folder if it doesn't exist
-                if (-not (Test-Path -Path $containerFolder)) {
-                    New-Item -ItemType Directory -Path $containerFolder | Out-Null
-                }
-                # URI builder for the blob storage
-                $uriBuilderEndpoint = New-Object System.UriBuilder($_.Groups['endpoint'].Value)
-                $requestHeaders = @{
-                    "Accept" = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
-                    "Accept-Language" = "en-US,en;q=0.5";
-                }
-                $requestHeadersVersion = @{
-                    "x-ms-version" = "2019-12-12";
-                    "Accept" = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
-                    "Accept-Language" = "en-US,en;q=0.5";
-                }
-
-                # Get Account Information
-                # /wo x-ms-version
-                $uriBuilderEndpoint.Path = "/" 
-                $uriBuilderEndpoint.Query = "restype=account&comp=properties"
-                $fileOutputPath = Join-Path -Path $containerFolder -ChildPath "account-information.xml"
-                $dataWebsite += "`t`t`tURI: $($uriBuilderEndpoint.Uri)"
-                try {
-                    $response = Invoke-WebRequest -Uri $uriBuilderEndpoint.Uri -Headers $requestHeaders
-                    $dataWebsite += "`t`t`t`tStatusCode: $($response.StatusCode)"
-                    $dataWebsite += "`t`t`t`tStatusDescription: $($response.StatusDescription)"
-
-                    if ($response.StatusCode -eq 200) {
-                        $response.Content | Out-File -FilePath $fileOutputPath
-                    }
-
-                } catch {
-                    $dataWebsite += "`t`t`t`tStatusCode: $($_.Exception.Response.StatusCode.value__)"
-                }
-
-                # Get Blob Service Properties
-                # /wo x-ms-version
-                $uriBuilderEndpoint.Path = "/" 
-                $uriBuilderEndpoint.Query = "restype=service&comp=properties"
-                $fileOutputPath = Join-Path -Path $containerFolder -ChildPath "service-properties.xml"
-                $dataWebsite += "`t`t`tURI: $($uriBuilderEndpoint.Uri)"
-                try {
-                    $response = Invoke-WebRequest -Uri $uriBuilderEndpoint.Uri -Headers $requestHeaders
-                    $dataWebsite += "`t`t`t`tStatusCode: $($response.StatusCode)"
-                    $dataWebsite += "`t`t`t`tStatusDescription: $($response.StatusDescription)"
-
-                    if ($response.StatusCode -eq 200) {
-                        $response.Content | Out-File -FilePath $fileOutputPath
-                    }
-
-                } catch {
-                    $dataWebsite += "`t`t`t`tStatusCode: $($_.Exception.Response.StatusCode.value__)"
-                }
-
-                # List Containers
-                # /wo x-ms-version
-                $uriBuilderEndpoint.Path = "/" 
-                $uriBuilderEndpoint.Query = "comp=list"
-                $fileOutputPath = Join-Path -Path $containerFolder -ChildPath "containers.xml"
-                $dataWebsite += "`t`t`tURI: $($uriBuilderEndpoint.Uri)"
-                try {
-                    $response = Invoke-WebRequest -Uri $uriBuilderEndpoint.Uri -Headers $requestHeaders
-                    $dataWebsite += "`t`t`t`tStatusCode: $($response.StatusCode)"
-                    $dataWebsite += "`t`t`t`tStatusDescription: $($response.StatusDescription)"
-
-                    if ($response.StatusCode -eq 200) {
-                        $response.Content | Out-File -FilePath $fileOutputPath
-                    }
-
-                } catch {
-                    $dataWebsite += "`t`t`t`tStatusCode: $($_.Exception.Response.StatusCode.value__)"
-                }
-
-                # List Blobs
-                # /w x-ms-version
-                $uriBuilderEndpoint.Path = "/$($container)"
-                $uriBuilderEndpoint.Query = "restype=container&comp=list&include=versions"
-                $fileOutputPath = Join-Path -Path $containerFolder -ChildPath "blobs.xml"
-                $dataWebsite += "`t`t`tURI: $($uriBuilderEndpoint.Uri)"
-                try {
-                    $response = Invoke-WebRequest -Uri $uriBuilderEndpoint.Uri -Headers $requestHeadersVersion
-                    $dataWebsite += "`t`t`t`tStatusCode: $($response.StatusCode)"
-                    $dataWebsite += "`t`t`t`tStatusDescription: $($response.StatusDescription)"
-
-                    if ($response.StatusCode -eq 200) {
-                        $response.Content | Out-File -FilePath $fileOutputPath
-
-                        $dataWebsite += "`t`t`t`tCheck Blobs:"
-                        $XmlDocument = New-Object System.XML.XMLDocument
-                        $XmlDocument.Load($fileOutputPath)
-                        $XmlDocument.EnumerationResults.Blobs.Blob | ForEach-Object {
-                            $dataWebsite += "`t`t`t`t`tName: $($_.Name); VersionId: $($_.VersionId); Content-Type: $($_.Properties.'Content-Type')"
-                        }
-                    }
-
-                } catch {
-                    $dataWebsite += "`t`t`t`tStatusCode: $($_.Exception.Response.StatusCode.value__)"
-                }
-
-            }
-
-        } else {
-            Write-Host "Failed to access the website. StatusCode: $($response.StatusCode)"
-        }
-
-        $dataWebsite | ForEach-Object { Add-Content -Path $logFile -Value $_ }
-    }
-
-} else {
-    Write-Host "Invalid parameter set."
+# Check if PowerShell version is 7.4 or higher
+if ($PSVersionTable.PSVersion.Major -lt 7) {
+    Write-Verbose -Message "PowerShell version is lower than 7.4, actual version is $($PSVersionTable.PSVersion) ..."
+    Write-Error -Message "PowerShell version 7.4 or higher is required" -Category NotInstalled
     exit
 }
+
+# Normalize case name to lowercase
+$caseFolderName = $CaseName.ToLower()
+$caseFolderName = $caseFolderName.Trim()
+$caseFolderName = $caseFolderName -replace '[\\/:*?"<>|]', '_'
+
+# Paths for logs (1/2)
+$baseFolderPath = Join-Path -Path (Get-Location) -ChildPath "case"
+$caseFolderPath = Join-Path -Path $baseFolderPath -ChildPath "$($caseFolderName)"
+
+Write-Verbose -Message "Checking folders (1/2) ..."
+
+# Create case folder if it doesn't exist
+if (-not (Test-Path -Path $baseFolderPath)) {
+    Write-Verbose -Message "Base folder does not exist, creating it..."
+    New-Item -ItemType Directory -Path $baseFolderPath | Out-Null
+}
+
+# Create domain folder if it doesn't exist
+if (-not (Test-Path -Path $caseFolderPath)) {
+    Write-Verbose -Message "Case folder does not exist, creating it..."
+    New-Item -ItemType Directory -Path $caseFolderPath | Out-Null
+}
+
+$websites = @()
+switch ($PSCmdlet.ParameterSetName) {
+    'Uri' {
+        $websites += $Uri
+        Write-Verbose -Message "Websites to check: $($websites)"
+    }
+
+    'File' {
+        Write-Verbose -Message "Reading websites from file $($FilePath) ..."
+        if (Test-Path -Path $FilePath -PathType Leaf) {
+            $websites += Get-Content -Path $FilePath
+            Write-Verbose -Message "Websites to check: $($websites)"
+        } else {
+            Write-Error -Message "File not found: $($FilePath)" -Category ObjectNotFound
+            exit
+        }
+    }
+}
+
+
+
+
+
+
+
+
+
+# Get actual date and time ...
+$timeEnd = Get-Date
+
+# Printout date&times ...
+Write-Output "***********************************************************"
+Write-Output "Started: $($timeStart)"
+Write-Output "Finished: $($timeEnd)"
+Write-Output "Elapsed time: $($timeEnd - $timeStart)"


### PR DESCRIPTION
This pull request standardizes error handling across multiple PowerShell scripts by replacing `Write-Output` with `Write-Error` for error messages and adding appropriate error categories. This improves the clarity and consistency of error reporting.

### Standardized Error Handling

* Replaced `Write-Output` with `Write-Error` for PowerShell version checks, module installation checks, and connection errors in the following scripts:
  - `scripts/private/get-entrausers.ps1` [[1]](diffhunk://#diff-6d47e2d1960903111d45665ff0c80db611cc74a9a5a38ead747692a2d99725a0L46-R53) [[2]](diffhunk://#diff-6d47e2d1960903111d45665ff0c80db611cc74a9a5a38ead747692a2d99725a0L103-R103)
  - `scripts/private/get-rolesassignment.ps1` [[1]](diffhunk://#diff-76f784d3fea45981870eb8126790d04ded52fc6d0fcd9e7100f0c943defb519aL46-R53) [[2]](diffhunk://#diff-76f784d3fea45981870eb8126790d04ded52fc6d0fcd9e7100f0c943defb519aL94-R94)
  - `scripts/private/get-storageaccounts.ps1` [[1]](diffhunk://#diff-c32f82f174ac5df7f109c7c4604749266b1b54c36a44f34ba310b930744e3dedL46-R53) [[2]](diffhunk://#diff-c32f82f174ac5df7f109c7c4604749266b1b54c36a44f34ba310b930744e3dedL94-R94)
  - `scripts/private/get-storageblob.ps1` [[1]](diffhunk://#diff-9ca5fc50ac70eb3491b88fb7d1be682a7a066609e1d9d4f47df7e1c6621193e2L78-R85) [[2]](diffhunk://#diff-9ca5fc50ac70eb3491b88fb7d1be682a7a066609e1d9d4f47df7e1c6621193e2L133-R133)
  - `scripts/private/get-virtualmachines.ps1` [[1]](diffhunk://#diff-1f4b2e248712250d48e3ed3cbb2536b5f6aa685d70da0acc6adab9541218e5b1L46-R53) [[2]](diffhunk://#diff-1f4b2e248712250d48e3ed3cbb2536b5f6aa685d70da0acc6adab9541218e5b1L94-R94)
  - `scripts/private/get-visibleresources.ps1` [[1]](diffhunk://#diff-ab7db8a59dd74846152d2358f77e77dc05a06a276cb7d5d265789cc1e4fef85fL45-R52) [[2]](diffhunk://#diff-ab7db8a59dd74846152d2358f77e77dc05a06a276cb7d5d265789cc1e4fef85fL93-R93)

* Added specific error categories (`NotInstalled`, `ConnectionError`, `ObjectNotFound`) to `Write-Error` calls for better error classification.

### Improved Error Reporting in `get-storageblob.ps1`

* Updated error handling for blob-related operations:
  - Replaced `Write-Output` with `Write-Error` for missing blob errors and failed downloads. [[1]](diffhunk://#diff-9ca5fc50ac70eb3491b88fb7d1be682a7a066609e1d9d4f47df7e1c6621193e2L149-R149) [[2]](diffhunk://#diff-9ca5fc50ac70eb3491b88fb7d1be682a7a066609e1d9d4f47df7e1c6621193e2L160-R160) [[3]](diffhunk://#diff-9ca5fc50ac70eb3491b88fb7d1be682a7a066609e1d9d4f47df7e1c6621193e2L172-R172) [[4]](diffhunk://#diff-9ca5fc50ac70eb3491b88fb7d1be682a7a066609e1d9d4f47df7e1c6621193e2L183-R183)…o include additional test files